### PR TITLE
Make .wsb file location independent

### DIFF
--- a/config.example.wsb
+++ b/config.example.wsb
@@ -1,7 +1,7 @@
 <Configuration>
 	<MappedFolders>
 		<MappedFolder>
-			<HostFolder>C:\Users\Username\wsb</HostFolder>
+			<HostFolder>.</HostFolder>
 			<SandboxFolder>C:\bootstrap</SandboxFolder>
 			<ReadOnly>true</ReadOnly>
 		</MappedFolder>


### PR DESCRIPTION
# Description

The host folder in the provided .wsb file is set to "." so that the config file becomes location independent and can be git-cloned anywhere.

- [x] I have read and understand the [guidelines for contributing](https://github.com/Strappazzon/wsb/blob/-/.github/CONTRIBUTING.md) to this repository.
- [ ] If this PR closes a ticket or fixes any issue, I added "Closes `#issue`" to the description or my commit message.
